### PR TITLE
Bump version: 0.1.0 → 0.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.2.0
 commit = True
 tag = False
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 	pytest tests/
 
 install_local:
-	pip install dist/promoted_python_delivery_client-0.1.0-py3-none-any.whl --force-reinstall
+	pip install dist/promoted_python_delivery_client-0.2.0-py3-none-any.whl --force-reinstall
 
 uninstall_local:
-	pip uninstall dist/promoted_python_delivery_client-0.1.0-py3-none-any.whl
+	pip uninstall dist/promoted_python_delivery_client-0.2.0-py3-none-any.whl

--- a/promoted_python_delivery_client/client/version.py
+++ b/promoted_python_delivery_client/client/version.py
@@ -1,1 +1,1 @@
-SERVER_VERSION = "python.0.1.0"
+SERVER_VERSION = "python.0.2.0"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
 # This call to setup() does all the work
 setup(
     name="promoted-python-delivery-client",
-    version="0.1.0",
+    version="0.2.0",
     description="Promoted.ai Python Delivery Client",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I had to bump this up one more because when I went to release I recalled that there was an old hidden 0.1.0 that I pushed when I was setting up the release process.