### PR TITLE
SDK delivery should create response insertions more like API delivery

### DIFF
--- a/promoted_python_delivery_client/client/sdk_delivery.py
+++ b/promoted_python_delivery_client/client/sdk_delivery.py
@@ -31,9 +31,12 @@ class SDKDelivery:
         final_insertion_size = min(size, len(req.insertion) - index)
         insertion_page: List[Insertion] = []
         for i in range(0, final_insertion_size):
-            ins = req.insertion[index]
-            self._prepare_response_insertion(ins, offset)
-            insertion_page.append(ins)
+            req_ins = req.insertion[index]
+
+            # Delivery response insertions only contain content_id + the fields added in _prepare_response_insertion
+            resp_ins = Insertion(content_id=req_ins.content_id)
+            self._prepare_response_insertion(resp_ins, offset)
+            insertion_page.append(resp_ins)
             index = index + 1
             offset = offset + 1
 

--- a/tests/test_sdk_delivery.py
+++ b/tests/test_sdk_delivery.py
@@ -1,7 +1,9 @@
 import pytest
 from promoted_python_delivery_client.client.delivery_request import DeliveryRequest
 from promoted_python_delivery_client.client.sdk_delivery import SDKDelivery
+from promoted_python_delivery_client.model.insertion import Insertion
 from promoted_python_delivery_client.model.paging import Paging
+from promoted_python_delivery_client.model.properties import Properties
 from promoted_python_delivery_client.model.request import Request
 from tests.utils_testing import create_test_request_insertions
 
@@ -20,6 +22,28 @@ def test_valid_paging_offset_and_insertion_start():
                   paging=Paging(size=10, offset=5))
     dreq = DeliveryRequest(req, insertion_start=5)
     SDKDelivery().run_delivery(dreq)
+
+
+def test_response_insertions_only_have_key_fields():
+    insertions = create_test_request_insertions(1)
+    req_ins = insertions[0]
+    req_ins.properties = Properties({"a": True})
+    req_ins.retrieval_rank = 3
+    req_ins.retrieval_score = 2.2
+
+    req = Request(insertion=insertions)
+    dreq = DeliveryRequest(req)
+    resp = SDKDelivery().run_delivery(dreq)
+
+    resp_ins = resp.insertion[0]
+    assert resp_ins.content_id == req_ins.content_id
+    assert resp_ins.properties is None
+    assert resp_ins.retrieval_rank is None
+    assert resp_ins.retrieval_score is None
+
+    assert req_ins.properties is not None
+    assert req_ins.retrieval_rank is not None
+    assert req_ins.retrieval_score is not None
 
 
 def test_no_paging_returns_all():


### PR DESCRIPTION
This will solve an issue where shadow traffic passes request insertions that have been modified to include position/insertion_id