### PR TITLE
feat: validate Delivery Response

### DIFF
--- a/promoted_python_delivery_client/client/delivery_request_state.py
+++ b/promoted_python_delivery_client/client/delivery_request_state.py
@@ -10,7 +10,7 @@ class DeliveryRequestState:
     delivery_request: DeliveryRequest
 
     def get_response_to_return(self, resp: Response) -> Response:
-        return resp
+        return _validate_response(resp)
 
     def get_request_to_send(self, max_request_insertions: int) -> Request:
         req = self.delivery_request.request
@@ -19,3 +19,9 @@ class DeliveryRequestState:
         if req.insertion_matrix and len(req.insertion_matrix) > max_request_insertions:
             req.insertion_matrix = req.insertion_matrix[0:max_request_insertions]
         return req
+
+
+def _validate_response(response: Response) -> Response:
+    if not response.request_id:
+        raise ValueError(f"Delivery Response must have request_id; response={response}")
+    return response

--- a/promoted_python_delivery_client/model/response.py
+++ b/promoted_python_delivery_client/model/response.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from dataclasses_json import dataclass_json, LetterCase
+from dataclasses import dataclass, field
+from dataclasses_json import config, dataclass_json, LetterCase
 from typing import List, Optional
 
 from promoted_python_delivery_client.model.insertion import Insertion
@@ -9,7 +9,8 @@ from promoted_python_delivery_client.model.paging_info import PagingInfo
 @dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass
 class Response:
-    insertion: List[Insertion]
+    request_id: str
+    # Delivery API can omit the `insertion` field if the list is empty.
+    insertion: List[Insertion] = field(default_factory=list)  # type: ignore
     paging_info: Optional[PagingInfo] = None
     introspection_data: Optional[str] = None
-    request_id: Optional[str] = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -68,7 +68,7 @@ def test_only_log_calls_sdk_delivery_and_logs(mocker: MockerFixture):
     req = Request(insertion=create_test_request_insertions(10))
     dreq = DeliveryRequest(request=req, only_log=True)
 
-    sdk_patch.return_value = Response(insertion=req.insertion)
+    sdk_patch.return_value = Response(request_id='reqid', insertion=req.insertion)
 
     resp = client.deliver(dreq)
     assert resp is not None
@@ -94,7 +94,7 @@ def test_custom_not_should_apply_treatment_calls_sdk_delivery_and_logs(mocker: M
     req = Request(insertion=create_test_request_insertions(10))
     dreq = DeliveryRequest(request=req, only_log=False)
 
-    sdk_patch.return_value = Response(insertion=req.insertion)
+    sdk_patch.return_value = Response(request_id='reqid', insertion=req.insertion)
 
     resp = client.deliver(dreq)
     assert resp is not None
@@ -120,7 +120,7 @@ def test_custom_should_apply_treatment_calls_api_delivery_and_does_not_log(mocke
     req = Request(insertion=create_test_request_insertions(10))
     dreq = DeliveryRequest(request=req, only_log=False)
 
-    api_patch.return_value = Response(insertion=req.insertion)
+    api_patch.return_value = Response(request_id='reqid', insertion=req.insertion)
 
     resp = client.deliver(dreq)
     assert resp is not None
@@ -145,7 +145,7 @@ def test_has_treatment_cohort_membership_calls_api_delivery_and_logs(mocker: Moc
     req = Request(insertion=create_test_request_insertions(10))
     dreq = DeliveryRequest(request=req, only_log=False, experiment=cm)
 
-    api_patch.return_value = Response(insertion=req.insertion)
+    api_patch.return_value = Response(request_id='reqid', insertion=req.insertion)
 
     resp = client.deliver(dreq)
     assert resp is not None
@@ -175,7 +175,7 @@ def test_has_control_cohort_membership_calls_sdk_delivery_and_logs(mocker: Mocke
     req = Request(insertion=create_test_request_insertions(10))
     dreq = DeliveryRequest(request=req, only_log=False, experiment=cm)
 
-    sdk_patch.return_value = Response(insertion=req.insertion)
+    sdk_patch.return_value = Response(request_id='reqid', insertion=req.insertion)
 
     resp = client.deliver(dreq)
     assert resp is not None
@@ -200,7 +200,7 @@ def test_api_delivery_error_falls_back_to_sdk_delivery(mocker: MockerFixture):
     req = Request(insertion=create_test_request_insertions(10))
     dreq = DeliveryRequest(request=req, only_log=False)
 
-    sdk_patch.return_value = Response(insertion=req.insertion)
+    sdk_patch.return_value = Response(request_id='reqid', insertion=req.insertion)
     api_patch.side_effect = Exception("oops")
 
     resp = client.deliver(dreq)

--- a/tests/test_delivery_request_state.py
+++ b/tests/test_delivery_request_state.py
@@ -1,7 +1,25 @@
+import pytest
 from promoted_python_delivery_client.client.delivery_request import DeliveryRequest
 from promoted_python_delivery_client.client.delivery_request_state import DeliveryRequestState
 from promoted_python_delivery_client.model.request import Request
+from promoted_python_delivery_client.model.response import Response
 from tests.utils_testing import create_test_request_insertions
+
+
+def test_validate_response():
+    raw_response = Response(request_id='reqid', insertion=[])
+    state = create_mock_state()
+    response = state.get_response_to_return(raw_response)
+    assert response.request_id == 'reqid'
+    assert response.insertion == raw_response.insertion
+
+
+def test_validate_response_no_request_id():
+    with pytest.raises(ValueError) as ex:
+        raw_response = Response(request_id='', insertion=[])
+        state = create_mock_state()
+        state.get_response_to_return(raw_response)
+    assert "Delivery Response must have request_id" in str(ex)
 
 
 def test_exactly_max_request_insertions():
@@ -38,3 +56,10 @@ def test_more_than_max_request_insertions_with_matrix():
     state = DeliveryRequestState(DeliveryRequest(req))
     to_send = state.get_request_to_send(5)
     assert len(to_send.insertion_matrix) == 5
+
+
+def create_mock_state():
+    """For the response tests since the request does not matter."""
+    insertion = create_test_request_insertions(10)
+    req = Request(insertion=insertion)
+    return DeliveryRequestState(DeliveryRequest(req))

--- a/tests/test_log_request.py
+++ b/tests/test_log_request.py
@@ -11,7 +11,7 @@ from promoted_python_delivery_client.client.serde import log_request_to_json_3
 
 def test_to_json():
     exec = DeliveryExecution(execution_server=ExecutionServer.API, server_version="python.1.1.1")
-    dl = DeliveryLog(Request(insertion=[]), Response(insertion=[]), exec)
+    dl = DeliveryLog(Request(insertion=[]), Response(request_id='', insertion=[]), exec)
     log_req = LogRequest(delivery_log=[dl])
 
     data_str = log_request_to_json_3(log_req)

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -1,8 +1,9 @@
+import pytest
 from promoted_python_delivery_client.model.insertion import Insertion
 from promoted_python_delivery_client.model.properties import Properties
 from promoted_python_delivery_client.model.request import Request
 from promoted_python_delivery_client.model.user_info import UserInfo
-from promoted_python_delivery_client.client.serde import delivery_request_to_json, delivery_request_to_json_2, delivery_request_to_json_3
+from promoted_python_delivery_client.client.serde import delivery_request_to_json, delivery_request_to_json_2, delivery_request_to_json_3, delivery_reponse_from_json_2
 
 
 def test_delivery_request_to_json():
@@ -78,3 +79,22 @@ def test_delivery_request_with_insertion_matrix_to_json_keeps_empty():
     payload = delivery_request_to_json_3(req)
 
     assert "[[null]]" in payload
+
+
+def test_delivery_reponse_from_json_2():
+    response = delivery_reponse_from_json_2(
+        '{"requestId":"reqid", "insertion": []}'.encode('utf-8'))
+    assert response.request_id == 'reqid'
+    assert len(response.insertion) == 0
+
+
+def test_delivery_reponse_from_json_2_empty():
+    with pytest.raises(KeyError) as ex:
+        response = delivery_reponse_from_json_2('{}'.encode('utf-8'))
+    assert "request_id" in str(ex)
+
+
+def test_delivery_reponse_from_json_2_no_insertions():
+    response = delivery_reponse_from_json_2('{"requestId":"reqid"}'.encode('utf-8'))
+    assert response.request_id == 'reqid'
+    assert len(response.insertion) == 0


### PR DESCRIPTION
fixes PRO-4312

Validation:
- Make sure `request_id` is set.  This might catch some bugs.

This PR also fixes something that might be a bug with how empty insertions works.  I think Delivery API omits the insertion field if it's empty.  The previous JSON parsing would raise an error if the `insertion` is missing.  This probably didn't matter since clients could avoid sending us cases that would result in empty response insertions.  This will event matter though for more advanced cases.

TESTING=unit tests